### PR TITLE
Dev/bjiang9/adding log msg

### DIFF
--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -20,7 +20,7 @@ class AccountRequest < ApplicationRecord
   # Check if user with same username or email already exists in Users table
   def validate_user_exists
     return unless User.find_by(name: self[:username])
-
+    ExpertizaLogger.warn LoggerMessage.new('Account Request Model', self[:username], "User with name #{self[:username]} already exists.")
     errors.add(:username, 'User with this username already exists')
   end
 end

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -1,6 +1,7 @@
 class Administrator < User
   def managed_users
     # Get all users that belong to an institution of the loggedIn user except the user itself
+    ExpertizaLogger.warn LoggerMessage.new('Administrator Model', session[:user].name, "User #{session[:user].name} fetched all users.")
     User.where(institution_id:).where.not(id:)
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -16,6 +16,7 @@ class Assignment < ApplicationRecord
   attr_accessor :title, :description, :has_badge, :enable_pair_programming, :is_calibrated, :staggered_deadline
 
   def review_questionnaire_id
+    ExpertizaLogger.info LoggerMessage.new("Assignment Model", session[:user].name, "User #{session[:user].name} searched for questionnaire for assignment #{id}.")
     Questionnaire.find_by_assignment_id id
   end
 
@@ -38,11 +39,13 @@ class Assignment < ApplicationRecord
     user = User.find_by(id: user_id)
     # Check if the user exists
     if user.nil?
+      ExpertizaLogger.warn LoggerMessage.new("Assignment Model", session[:user].name, "User #{user_id} does not exist. Not added to assignment #{id}.")
       raise "The user account does not exist"
     end
     # Check if the user is already a participant in the assignment
     participant = Participant.find_by(assignment_id:id, user_id:user.id)
     if participant
+      ExpertizaLogger.warn LoggerMessage.new("Assignment Model", user.id, "User #{user.id} already a participant on assignment #{id}.")
       # Raises error if the user is already a participant
       raise "The user #{user.name} is already a participant."
     end
@@ -51,6 +54,7 @@ class Assignment < ApplicationRecord
                                             user_id: user.id)
     # Set the participant's handle
     new_part.set_handle
+    ExpertizaLogger.info LoggerMessage.new("Assignment Model", user.id, "User #{user.id} added to assignment #{id}.")
     # Return the newly created AssignmentParticipant
     new_part
   end
@@ -65,6 +69,7 @@ class Assignment < ApplicationRecord
     assignment_participant = AssignmentParticipant.where(assignment_id: self.id, user_id: user_id).first
     # Delete the AssignmentParticipant record
     if assignment_participant
+      ExpertizaLogger.info LoggerMessage.new("Assignment Model", session[:user].name, "User #{session[:user].name} removed user #{user_id} from assignment #{id}.")
       assignment_participant.destroy
     end
   end
@@ -74,6 +79,7 @@ class Assignment < ApplicationRecord
   # Returns the modified assignment object with course_id set to nil.
   def remove_assignment_from_course
     # Set the course_id of the assignment to nil
+    ExpertizaLogger.info LoggerMessage.new("Assignment Model", session[:user].name, "User #{session[:user].name} removed assignment #{id} from course #{self.course_id}.")
     self.course_id = nil
     # Return the modified assignment
     self
@@ -89,11 +95,13 @@ class Assignment < ApplicationRecord
     assignment = Assignment.where(id: id).first
     # Check if the assignment already belongs to the provided course_id
     if assignment.course_id == course_id
+      ExpertizaLogger.warn LoggerMessage.new("Assignment Model", session[:user].name, "Assignment #{id} already added to course #{course_id}.")
       # Raises error if the assignment already belongs to the provided course_id
       raise "The assignment already belongs to this course id."
     end
     # Update the assignment's course assignment
     assignment.course_id = course_id
+    ExpertizaLogger.info LoggerMessage.new("Assignment Model", session[:user].name, "User #{session[:user].name} added assignment #{id} to course #{course_id}.")
     # Return the modified assignment
     assignment
   end
@@ -113,7 +121,7 @@ class Assignment < ApplicationRecord
 
     # Save the copied assignment to the database
     copied_assignment.save
-
+    ExpertizaLogger.info LoggerMessage.new("Assignment Model", session[:user].name, "User #{session[:user].name} copied assignment #{id}.")
     copied_assignment
 
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,16 +15,20 @@ class Course < ApplicationRecord
   # Add a Teaching Assistant to the course
   def add_ta(user)
     if user.nil?
-      return { success: false, message: "The user with id #{user.id} does not exist" }
+      ExpertizaLogger.warn LoggerMessage.new("Course Model", session[:user].name, "User not found. No TA added to course #{id}")
+      return { success: false, message: "The user with id #{user} does not exist" }
     elsif TaMapping.exists?(ta_id: user.id, course_id: id)
+      ExpertizaLogger.warn LoggerMessage.new("Course Model", session[:user].name, "User #{user.id} already a TA for course #{id}.")
       return { success: false, message: "The user with id #{user.id} is already a TA for this course." }
     else
       ta_mapping = TaMapping.create(ta_id: user.id, course_id: id)
       user.update(role: Role::TEACHING_ASSISTANT)
       if ta_mapping.save
+        ExpertizaLogger.info LoggerMessage.new("Course Model", session[:user].name, "User #{user.id} added as TA to course #{id}.")
         return { success: true, data: ta_mapping.slice(:course_id, :ta_id) }
       else
-        return { success: false, message: ta_mapping.errors }
+        ExpertizaLogger.warn LoggerMessage.new("Course Model", session[:user].name, "Error added user #{user.id} as TA to course #{id}.")
+      return { success: false, message: ta_mapping.errors }
       end
     end
   end
@@ -32,13 +36,16 @@ class Course < ApplicationRecord
   # Removes Teaching Assistant from the course
   def remove_ta(ta_id)
     ta_mapping = ta_mappings.find_by(ta_id: ta_id, course_id: :id)
+    ExpertizaLogger.warn LoggerMessage.new("Course Model", session[:user].name, "User #{ta_id} not associated with course #{id}.")
     return { success: false, message: "No TA mapping found for the specified course and TA" } if ta_mapping.nil?
     ta = User.find(ta_mapping.ta_id)
     ta_count = TaMapping.where(ta_id: ta_id).size - 1
     if ta_count.zero?
+      ExpertizaLogger.info LoggerMessage.new("Course Model", session[:user].name, "User #{ta_id} changed from TA to student for course #{id}.")
       ta.update(role: Role::STUDENT)
     end
     ta_mapping.destroy
+    ExpertizaLogger.info LoggerMessage.new("Course Model", session[:user].name, "User #{ta_id} removed from course #{id}.")
     { success: true, ta_name: ta.name }
   end
 
@@ -47,6 +54,7 @@ class Course < ApplicationRecord
     new_course = dup
     new_course.directory_path += '_copy'
     new_course.name += '_copy'
+    ExpertizaLogger.info LoggerMessage.new("Course Model", session[:user].name, "User #{session[:user].name} copied course #{id}.")
     new_course.save
   end
 end

--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -2,6 +2,8 @@ class Instructor < User
 
   # Get all users whose parent is the instructor
   def managed_users
+    ExpertizaLogger.info LoggerMessage.new("Instructor Model", session[:user].name,
+                                           "User #{session[:name].name} found all instructors with parent ID #{id}.")
     User.where(parent_id: id).to_a
   end
 

--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -3,7 +3,7 @@ class Instructor < User
   # Get all users whose parent is the instructor
   def managed_users
     ExpertizaLogger.info LoggerMessage.new("Instructor Model", session[:user].name,
-                                           "User #{session[:name].name} found all instructors with parent ID #{id}.")
+                                           "User #{session[:user].name} found all instructors with parent ID #{id}.")
     User.where(parent_id: id).to_a
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -10,6 +10,8 @@ class Invitation < ApplicationRecord
   # Return a new invitation
   # params = :assignment_id, :to_id, :from_id, :reply_status
   def self.invitation_factory(params)
+    ExpertizaLogger.info LoggerMessage.new("Invitation Model", session[:user].name,
+                 "User #{session[:user].name} created new invitation for assignment #{params[:assignment_id]}.")
     Invitation.new(params)
   end
 
@@ -26,6 +28,8 @@ class Invitation < ApplicationRecord
 
   # send invite email
   def send_invite_email
+    ExpertizaLogger.info LoggerMessage.new("Invitation Model", session[:user].name,
+                                           "Email invitation for assignment #{assignment_id} sent.")
     InvitationSentMailer.with(invitation: self)
                         .send_invitation_email
                         .deliver_later
@@ -42,16 +46,22 @@ class Invitation < ApplicationRecord
   # Lastly the users team entry will be added to the TeamsUser table and their assigned topic is updated.
   # NOTE: For now this method simply updates the invitation's reply_status.
   def accept_invitation(_logged_in_user)
+    ExpertizaLogger.info LoggerMessage.new("Invitation Model", session[:user].name,
+                                           "User #{_logged_in_user} accepted invitation for assignment #{assignment_id}.")
     update(reply_status: InvitationValidator::ACCEPT_STATUS)
   end
 
   # This method handles all that needs to be done upon an user declining an invitation.
   def decline_invitation(_logged_in_user)
+    ExpertizaLogger.info LoggerMessage.new("Invitation Model", session[:user].name,
+                                           "User #{_logged_in_user} declined invitation for assignment #{assignment_id}.")
     update(reply_status: InvitationValidator::REJECT_STATUS)
   end
 
   # This method handles all that need to be done upon an invitation retraction.
   def retract_invitation(_logged_in_user)
+    ExpertizaLogger.info LoggerMessage.new("Invitation Model", session[:user].name,
+                                           "User #{_logged_in_user} destroyed invitation for assignment #{assignment_id}.")
     destroy
   end
 

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -22,6 +22,8 @@ class Questionnaire < ApplicationRecord
       new_question.questionnaire_id = questionnaire.id
       new_question.save!
     end
+    ExpertizaLogger.info LoggerMessage.new("Questionnaire Model", session[:user].name,
+                                           "User #{session[:user]} copied details for questionnaire #{params[:id]}.")
     questionnaire
   end
 

--- a/app/models/response_map.rb
+++ b/app/models/response_map.rb
@@ -8,7 +8,10 @@ class ResponseMap < ApplicationRecord
 
   # returns the assignment related to the response map
   def response_assignment
-    return Participant.find(self.reviewer_id).assignment
+    assignment = Participant.find(self.reviewer_id).assignment
+    ExpertizaLogger.info LoggerMessage.new("Response Map Model", session[:user].name,
+                                           "Response to assignment #{assignment.id} for reviewer #{self.reviewer_id} retrieved.")
+    assignment
   end
 
   def self.assessments_for(team)
@@ -35,6 +38,8 @@ class ResponseMap < ApplicationRecord
         sort_to.clear
       end
       responses = responses.sort { |a, b| a.map.reviewer.fullname <=> b.map.reviewer.fullname }
+      ExpertizaLogger.info LoggerMessage.new("Response Map Model", session[:user].name,
+                                             "User #{session[:user].name} retrieved responses to team #{team.id}.")
     end
     responses
   end

--- a/app/models/student_task.rb
+++ b/app/models/student_task.rb
@@ -13,6 +13,8 @@ class StudentTask
 
     # create a new StudentTask instance from a Participant object.cccccccc
     def self.create_from_participant(participant)
+      ExpertizaLogger.info LoggerMessage.new("Student Task Model", session[:user].name,
+                                             "New student task created from information for participant #{participant.fullname}")
       new(
         assignment: participant.assignment.name,                          # Name of the assignment associated with the student task
         topic: participant.topic,                                         # Current stage of the assignment process
@@ -26,6 +28,8 @@ class StudentTask
 
     # create an array of StudentTask instances for all participants linked to a user, sorted by deadline.
     def self.from_user(user)
+      ExpertizaLogger.info LoggerMessage.new("Student Task Model", session[:user].name,
+                                             "List of tasks retrieved for User #{user.id}",)
       Participant.where(user_id: user.id)
                  .map { |participant| StudentTask.create_from_participant(participant) }
                  .sort_by(&:stage_deadline)

--- a/app/models/super_administrator.rb
+++ b/app/models/super_administrator.rb
@@ -1,5 +1,7 @@
 class SuperAdministrator < User
   def managed_users
+    ExpertizaLogger.info LoggerMessage.new("Super Administrator Model", session[:user].name,
+                                           "User #{session[:user].name} retrieved all users.")
     User.all.to_a
   end
 end

--- a/app/models/teams_user.rb
+++ b/app/models/teams_user.rb
@@ -10,6 +10,8 @@ class TeamsUser < ApplicationRecord
     team_members = TeamsUser.where('team_id = ?', team_id)
     user_ids = team_members.pluck(:user_id)
     users = User.where(id: user_ids)
+    ExpertizaLogger.info LoggerMessage.new("Team Users Model", session[:user].name,
+                                           "User #{session[:user].name} fetched the members of team #{team_id}.",)
 
     return users
   end
@@ -18,6 +20,9 @@ class TeamsUser < ApplicationRecord
   def self.remove_team(user_id, team_id)
     team_user = TeamsUser.where('user_id = ? and team_id = ?', user_id, team_id).first
     team_user&.destroy
+    ExpertizaLogger.info LoggerMessage.new("Team User Model", session[:user].name,
+                                           "User#{session[:name].name} removed user #{user_id} from team #{team_id}.")
+
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,7 @@ class User < ApplicationRecord
       short_name = login.split('@').first
       user_list = User.where(name: short_name)
       user = user_list.first if user_list.one?
+
     end
     user
   end
@@ -63,6 +64,9 @@ class User < ApplicationRecord
   def reset_password
     random_password = SecureRandom.alphanumeric(10)
     user.password_digest = BCrypt::Password.create(random_password)
+    ExpertizaLogger.info LoggerMessage.new("User Model", session[:user].name,
+                                           "User #{id}'s password was reset.",)
+
     user.save
   end
 


### PR DESCRIPTION
DO NOT MERGE TO MAIN

We discussed with our mentor in a meeting it would be better to not include model level logging.
It would create redundant logs for the same request (once when model functions are called, once at the end of the controller call)

Other notes if Model level logs are later added back:
- At time of writing, we believe errors are being thrown with the call `session[:user].name`. There are instances where the user is nil. Please look future pull requests for the remedy used.

- The generator field in LoggerMessage construction is currently written in as strings. To quickly replace these, in RubyMine, use Ctrl-F and turn on Regex mode (a button with .* should be an option). The Regex `'.* Model'` should find instances of the explicit string across all model classes.
  - If single quotes yield not results, try double quotes